### PR TITLE
Add Acoustics and PDE tools with named boundary selections and mesh sequence support

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ comsol_mcp/
 | `param_sweep_setup` | Setup parametric sweep |
 | `param_description` | Get/set description |
 
-### Geometry (14)
+### Geometry (16)
 
 | Tool | Description |
 |------|-------------|
@@ -198,8 +198,10 @@ comsol_mcp/
 | `geometry_build` | Build geometry |
 | `geometry_list_features` | List features |
 | `geometry_get_boundaries` | Get boundary numbers |
+| `geometry_create_box_selection` | Create a named selection by position |
+| `geometry_create_side_selections` | Create left/right/top/bottom selections |
 
-### Physics (16)
+### Physics (28)
 
 | Tool | Description |
 |------|-------------|
@@ -210,7 +212,18 @@ comsol_mcp/
 | `physics_add_solid_mechanics` | Add Solid Mechanics |
 | `physics_add_heat_transfer` | Add Heat Transfer |
 | `physics_add_laminar_flow` | Add Laminar Flow |
+| `physics_add_acoustics` | Add a geometry-based acoustic interface by COMSOL type |
+| `physics_add_pressure_acoustics` | Add Pressure Acoustics |
+| `physics_add_coefficient_form_pde` | Add Coefficient Form PDE |
+| `physics_add_general_form_pde` | Add General Form PDE |
+| `physics_add_weak_form_pde` | Add Weak Form PDE |
 | `physics_configure_boundary` | Configure boundary condition |
+| `physics_configure_acoustic_boundary` | Configure one acoustic boundary condition |
+| `physics_setup_acoustic_boundaries` | Configure multiple acoustic boundary conditions |
+| `physics_configure_pde_boundary` | Configure one PDE boundary condition |
+| `physics_setup_pde_boundaries` | Configure multiple PDE boundary conditions |
+| `physics_get_acoustic_boundary_conditions` | List common acoustic boundary feature types |
+| `physics_get_pde_boundary_conditions` | List common PDE boundary feature types |
 | `physics_set_material` | Assign material |
 | `physics_list_features` | List physics features |
 | `physics_remove` | Remove physics |
@@ -220,11 +233,12 @@ comsol_mcp/
 | `physics_interactive_setup_flow` | Interactive flow BC setup |
 | `physics_boundary_selection` | Generic boundary setup |
 
-### Mesh (3)
+### Mesh (4)
 
 | Tool | Description |
 |------|-------------|
 | `mesh_list` | List mesh sequences |
+| `mesh_create_sequence` | Create a mesh sequence |
 | `mesh_create` | Generate mesh |
 | `mesh_info` | Get mesh statistics |
 
@@ -368,6 +382,20 @@ bc.set('U0', '1[mm/s]')
 | Heat Transfer | ConvectiveHeatFlux | `h`, `Text` |
 | Laminar Flow | InletBoundary | `U0`, `NormalInflowVelocity` |
 | Laminar Flow | OutletBoundary | `p0` |
+| Pressure Acoustics | SoundHard | No additional property |
+| Pressure Acoustics | SoundSoft | No additional property |
+| Pressure Acoustics | Pressure | `p0` |
+| Pressure Acoustics | Impedance | `Zn` |
+| Pressure Acoustics | NormalAcceleration | `nacc` |
+| Pressure Acoustics | NormalVelocity | `nvel` |
+| Pressure Acoustics | PlaneWaveRadiation | No additional property |
+| Pressure Acoustics | SphericalWaveRadiation | No additional property |
+| PDE | DirichletBoundary | `r` |
+| PDE | FluxBoundary | `g`, `q` |
+| PDE | ZeroFluxBoundary | No additional property |
+| PDE | WeakContribution | `weak` |
+| PDE | PeriodicCondition | No additional property |
+
 
 ### 3. Client Session Limitation
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -180,7 +180,7 @@ COMSOL_Multiphysics_MCP/
 | `param_sweep_setup` | 设置参数扫描 |
 | `param_description` | 获取/设置参数描述 |
 
-### 几何建模（14 个）
+### 几何建模（16 个）
 
 | 工具 | 说明 |
 |------|------|
@@ -198,8 +198,10 @@ COMSOL_Multiphysics_MCP/
 | `geometry_build` | 构建几何 |
 | `geometry_list_features` | 列出特征 |
 | `geometry_get_boundaries` | 获取边界编号 |
+| `geometry_create_box_selection` | 按位置创建命名选择 |
+| `geometry_create_side_selections` | 创建左/右/上/下边界选择 |
 
-### 物理场配置（16 个）
+### 物理场配置（28 个）
 
 | 工具 | 说明 |
 |------|------|
@@ -210,7 +212,18 @@ COMSOL_Multiphysics_MCP/
 | `physics_add_solid_mechanics` | 添加固体力学 |
 | `physics_add_heat_transfer` | 添加传热 |
 | `physics_add_laminar_flow` | 添加层流 |
+| `physics_add_acoustics` | 按 COMSOL 类型添加基于几何的声学接口 |
+| `physics_add_pressure_acoustics` | 添加压力声学 |
+| `physics_add_coefficient_form_pde` | 添加系数形式 PDE |
+| `physics_add_general_form_pde` | 添加一般形式 PDE |
+| `physics_add_weak_form_pde` | 添加弱形式 PDE |
 | `physics_configure_boundary` | 配置边界条件 |
+| `physics_configure_acoustic_boundary` | 配置单个声学边界条件 |
+| `physics_setup_acoustic_boundaries` | 批量配置声学边界条件 |
+| `physics_configure_pde_boundary` | 配置单个 PDE 边界条件 |
+| `physics_setup_pde_boundaries` | 批量配置 PDE 边界条件 |
+| `physics_get_acoustic_boundary_conditions` | 列出常用声学边界 feature 类型 |
+| `physics_get_pde_boundary_conditions` | 列出常用 PDE 边界 feature 类型 |
 | `physics_set_material` | 分配材料 |
 | `physics_list_features` | 列出物理场特征 |
 | `physics_remove` | 删除物理场 |
@@ -220,11 +233,12 @@ COMSOL_Multiphysics_MCP/
 | `physics_interactive_setup_flow` | 交互式流体设置 |
 | `physics_boundary_selection` | 通用边界设置 |
 
-### 网格划分（3 个）
+### 网格划分（4 个）
 
 | 工具 | 说明 |
 |------|------|
 | `mesh_list` | 列出网格序列 |
+| `mesh_create_sequence` | 创建网格序列 |
 | `mesh_create` | 生成网格 |
 | `mesh_info` | 获取网格统计 |
 
@@ -340,6 +354,19 @@ bc.set('q0', '1e6[W/m^2]')
 | 层流 | OutletBoundary | `p0` |
 | 固体力学 | Fixed | 无额外属性 |
 | 固体力学 | BoundaryLoad | `Fx`，`Fy`，`Fz` |
+| 压力声学 | SoundHard | 无额外属性 |
+| 压力声学 | SoundSoft | 无额外属性 |
+| 压力声学 | Pressure | `p0` |
+| 压力声学 | Impedance | `Zn` |
+| 压力声学 | NormalAcceleration | `nacc` |
+| 压力声学 | NormalVelocity | `nvel` |
+| 压力声学 | PlaneWaveRadiation | 无额外属性 |
+| 压力声学 | SphericalWaveRadiation | 无额外属性 |
+| PDE | DirichletBoundary | `r` |
+| PDE | FluxBoundary | `g`，`q` |
+| PDE | ZeroFluxBoundary | 无额外属性 |
+| PDE | WeakContribution | `weak` |
+| PDE | PeriodicCondition | 无额外属性 |
 
 ### 离线嵌入模型
 

--- a/src/knowledge/embedded.py
+++ b/src/knowledge/embedded.py
@@ -17,7 +17,17 @@ KNOWLEDGE_FILES = {
         "file": "physics_guide.md",
         "description": "Guide to physics interfaces and boundary conditions",
         "title": "Physics Interfaces Guide",
-        "keywords": ["physics", "electrostatics", "heat", "solid", "fluid", "boundary", "condition"],
+        "keywords": [
+            "physics",
+            "electrostatics",
+            "heat",
+            "solid",
+            "fluid",
+            "acoustics",
+            "pde",
+            "boundary",
+            "condition",
+        ],
     },
     "workflow": {
         "file": "workflow.md",
@@ -66,6 +76,69 @@ TOPIC_GUIDES = {
             "Check Reynolds number to determine if laminar or turbulent flow",
             "Pressure outlet is commonly set to zero gauge pressure",
             "No-slip wall is the default condition for solid surfaces",
+        ],
+    },
+    "pressure_acoustics": {
+        "physics": "pressure_acoustics",
+        "boundary_conditions": [
+            "SoundHard",
+            "SoundSoft",
+            "Pressure",
+            "Impedance",
+            "NormalAcceleration",
+            "NormalVelocity",
+            "PlaneWaveRadiation",
+            "SphericalWaveRadiation",
+        ],
+        "common_expressions": ["acpr.p_t", "acpr.Lp_t", "acpr.Ix"],
+        "tips": [
+            "Use SoundHard for a rigid wall and SoundSoft for zero acoustic pressure",
+            "Use Impedance when the boundary response is described by acoustic impedance",
+            "Use a radiation boundary to reduce reflections at an open boundary",
+        ],
+    },
+    "coefficient_form_pde": {
+        "physics": "coefficient_form_pde",
+        "boundary_conditions": [
+            "DirichletBoundary",
+            "FluxBoundary",
+            "ZeroFluxBoundary",
+            "PeriodicCondition",
+        ],
+        "common_expressions": ["c", "a", "f", "da", "ea", "al", "be", "ga"],
+        "tips": [
+            "Set coefficient values through equation_properties",
+            "Coefficient dimensions depend on the number of dependent variables",
+            "Use physics_get_pde_boundary_conditions for boundary property names",
+        ],
+    },
+    "general_form_pde": {
+        "physics": "general_form_pde",
+        "boundary_conditions": [
+            "DirichletBoundary",
+            "FluxBoundary",
+            "ZeroFluxBoundary",
+            "PeriodicCondition",
+        ],
+        "common_expressions": ["Ga", "f", "da", "ea"],
+        "tips": [
+            "Set the conservative flux with the Ga equation property",
+            "General-form values may be scalar, vector, or matrix expressions",
+            "Use physics_get_pde_boundary_conditions for boundary property names",
+        ],
+    },
+    "weak_form_pde": {
+        "physics": "weak_form_pde",
+        "boundary_conditions": [
+            "DirichletBoundary",
+            "WeakContribution",
+            "PeriodicCondition",
+        ],
+        "common_expressions": ["weak"],
+        "tips": [
+            "Set the domain weak expression through equation_properties",
+            "Use WeakContribution for an additional weak boundary contribution",
+            "Dependent-variable names are user-defined and default to u",
         ],
     },
 }
@@ -485,6 +558,10 @@ def register_knowledge_tools(mcp: FastMCP) -> None:
         - "heat_transfer": Thermal analysis
         - "solid_mechanics": Stress and deformation
         - "fluid_flow": CFD analysis
+        - "pressure_acoustics": Frequency-domain pressure acoustics
+        - "coefficient_form_pde": Coefficient Form PDE
+        - "general_form_pde": General Form PDE
+        - "weak_form_pde": Weak Form PDE
         
         Args:
             physics_type: Type of physics to get guide for

--- a/src/knowledge/prompts/physics_guide.md
+++ b/src/knowledge/prompts/physics_guide.md
@@ -150,6 +150,202 @@ physics_configure_boundary("Laminar Flow", "Outlet", [2], {"p0": "0[Pa]"})
 - `spf.U` - Velocity magnitude
 - `spf.rho` - Density
 
+## Acoustics Module
+
+### Pressure Acoustics (acpr)
+
+For frequency-domain propagation of pressure waves in fluids.
+
+**Key Features:**
+- Acoustic pressure and sound pressure level
+- Radiation and impedance boundaries
+- Prescribed pressure, velocity, and acceleration sources
+- Domain restriction through explicit domain selections
+
+**Add the Interface:**
+```
+physics_add_pressure_acoustics(
+    physics_tag="acpr",
+    domain_selection=[1]
+)
+```
+
+Use `physics_add_acoustics` when an installed Acoustics Module interface does
+not have a dedicated MCP tool. Pass the exact COMSOL Java API physics type:
+
+```
+physics_add_acoustics(
+    physics_type="ThermoacousticsSinglePhysics",
+    physics_tag="ta"
+)
+```
+
+Availability depends on the installed COMSOL products, licenses, and version.
+
+**Common Boundary Features and Properties:**
+
+| Feature Type | Purpose | Common Properties |
+|--------------|---------|-------------------|
+| `SoundHard` | Rigid wall | None |
+| `SoundSoft` | Zero acoustic pressure | None |
+| `Pressure` | Prescribed acoustic pressure | `p0` |
+| `Impedance` | Specific acoustic impedance | `Zn` |
+| `NormalAcceleration` | Prescribed normal acceleration | `nacc` |
+| `NormalVelocity` | Prescribed normal velocity | `nvel` |
+| `PlaneWaveRadiation` | Plane-wave radiation boundary | None |
+| `SphericalWaveRadiation` | Spherical-wave radiation boundary | None |
+
+Use `physics_get_acoustic_boundary_conditions` to retrieve this reference
+programmatically. Version-specific feature types can still be passed through
+the specialized configuration tools.
+
+**Configure One Boundary:**
+```
+physics_configure_acoustic_boundary(
+    physics_name="acpr",
+    boundary_condition="Impedance",
+    selection_name="duct_outlet",
+    properties={"Zn": "rho0*c0"}
+)
+```
+
+`selection_name` binds the feature to a stable named COMSOL selection.
+Alternatively, provide `boundary_selection=[3]` with explicit entity numbers.
+
+**Configure Multiple Boundaries:**
+```
+physics_setup_acoustic_boundaries(
+    physics_name="acpr",
+    boundary_conditions=[
+        {
+            "type": "NormalVelocity",
+            "selection_name": "duct_inlet",
+            "properties": {"nvel": "inlet_velocity"}
+        },
+        {
+            "type": "PlaneWaveRadiation",
+            "selection_name": "duct_outlet"
+        },
+        {
+            "type": "SoundHard",
+            "selection_name": "duct_walls"
+        }
+    ]
+)
+```
+
+**Useful Expressions:**
+- `acpr.p_t` - Total acoustic pressure
+- `acpr.Lp_t` - Total sound pressure level
+- `acpr.Ix` - Acoustic intensity component in the x direction
+
+Expression names can vary with the acoustic interface and COMSOL version.
+
+## Mathematics Interfaces
+
+The PDE tools create geometry-based Coefficient Form, General Form, and Weak
+Form PDE interfaces. Dependent-variable names are user-defined and default to
+`u`. Scalar, vector, or matrix equation properties may be required when more
+than one dependent variable is used.
+
+### Coefficient Form PDE (c)
+
+For equations expressed using mass, damping, diffusion, convection, absorption,
+and source coefficients.
+
+```
+physics_add_coefficient_form_pde(
+    dependent_variables=["u"],
+    equation_properties={
+        "c": "1",
+        "a": "0",
+        "f": "source",
+        "da": "0",
+        "ea": "0"
+    },
+    physics_tag="c"
+)
+```
+
+Common equation properties are `c`, `a`, `f`, `da`, `ea`, `al`, `be`, and
+`ga`.
+
+### General Form PDE (g)
+
+For equations defined by a conservative flux and source terms.
+
+```
+physics_add_general_form_pde(
+    dependent_variables=["u"],
+    equation_properties={
+        "Ga": "-D*grad(u)",
+        "f": "source",
+        "da": "0",
+        "ea": "0"
+    },
+    physics_tag="g"
+)
+```
+
+Common equation properties are `Ga`, `f`, `da`, and `ea`.
+
+### Weak Form PDE (w)
+
+For equations specified directly as weak expressions.
+
+```
+physics_add_weak_form_pde(
+    dependent_variables=["u"],
+    equation_properties={"weak": "test(u)*(source-u)"},
+    physics_tag="w"
+)
+```
+
+The common equation property is `weak`.
+
+### PDE Boundary Conditions
+
+| Feature Type | Purpose | Common Properties |
+|--------------|---------|-------------------|
+| `DirichletBoundary` | Prescribed dependent-variable value | `r` |
+| `FluxBoundary` | Generalized inward flux or source | `g`, `q` |
+| `ZeroFluxBoundary` | Zero inward flux | None |
+| `WeakContribution` | Additional weak boundary contribution | `weak` |
+| `PeriodicCondition` | Periodic boundary condition | None |
+
+The aliases `dirichlet`, `flux`, `neumann`, `zero_flux`, `no_flux`, `wall`,
+`weak`, and `periodic` are accepted by the PDE boundary tools. Use
+`physics_get_pde_boundary_conditions` to retrieve the current feature,
+property, and alias reference.
+
+**Configure PDE Boundaries:**
+```
+physics_setup_pde_boundaries(
+    physics_name="c",
+    boundary_conditions=[
+        {
+            "type": "dirichlet",
+            "selection_name": "domain_left",
+            "properties": {"r": "0"}
+        },
+        {
+            "type": "flux",
+            "selection_name": "domain_right",
+            "properties": {"g": "boundary_source", "q": "0"}
+        },
+        {
+            "type": "zero_flux",
+            "selection_name": "domain_top"
+        }
+    ]
+)
+```
+
+For both acoustics and PDE tools, inspect `property_errors`,
+`failed_boundaries`, and `failed_count` in the returned result. A feature can
+be created successfully while one or more version-specific properties are
+rejected by COMSOL.
+
 ## Multiphysics Couplings
 
 ### Thermal Stress (ts)
@@ -209,6 +405,13 @@ Common material properties needed for different physics:
 | Heat Transfer | Thermal conductivity (k), Specific heat (Cp), Density (ρ) |
 | Laminar Flow | Density (ρ), Dynamic viscosity (μ) |
 
+Additional requirements for the newly supported interfaces:
+
+| Physics | Required Properties |
+|---------|---------------------|
+| Pressure Acoustics | Density, Speed of sound |
+| PDE Interfaces | Coefficients defined by the governing equation |
+
 ## Selection of Physics Interface
 
 When choosing physics interfaces, consider:
@@ -229,4 +432,8 @@ Different physics require appropriate study types:
 | Solid Mechanics | Stationary, Eigenfrequency |
 | Heat Transfer | Stationary, Time Dependent |
 | Fluid Flow | Stationary, Time Dependent |
+| Pressure Acoustics | Frequency |
+| Coefficient Form PDE | Stationary, Time Dependent, Eigenfrequency |
+| General Form PDE | Stationary, Time Dependent |
+| Weak Form PDE | Depends on the weak equation |
 | Multiphysics | Depends on coupling |

--- a/src/knowledge/prompts/workflow.md
+++ b/src/knowledge/prompts/workflow.md
@@ -54,7 +54,46 @@ This guide describes the typical workflow for creating and running COMSOL simula
 └─────────────────────────────────────────────────────┘
 ```
 
-### 3. Solve and Analyze
+### 3. Stable Selections and Mesh
+
+Boundary numbers can change after geometry operations. Prefer named selections
+when boundary conditions must remain stable across geometry revisions.
+
+For a rectangular 2D domain:
+
+```
+geometry_build()
+geometry_create_side_selections(
+    x_min="0[m]",
+    x_max="domain_width",
+    y_min="0[m]",
+    y_max="domain_height",
+    prefix="domain",
+    entity_dimension=1
+)
+```
+
+This creates `domain_left`, `domain_right`, `domain_bottom`, and
+`domain_top`. Pass these tags as `selection_name` when configuring acoustic or
+PDE boundaries.
+
+`mesh_create` runs existing mesh sequences. If no mesh sequence exists, its
+default `auto_create=True` behavior creates `mesh1` and binds it to the
+selected or first geometry:
+
+```
+mesh_create(
+    mesh_name="mesh1",
+    geometry_name="geom1",
+    component_name="comp1"
+)
+```
+
+Use `mesh_create_sequence` first when the mesh tag and geometry association
+must be created explicitly. Build the geometry before evaluating selections or
+generating the mesh.
+
+### 4. Solve and Analyze
 
 ```
 ┌─────────────────────────────────────────────────────┐
@@ -161,6 +200,182 @@ study_solve()
 stress = results_evaluate("solid.mises", "MPa")
 displacement = results_global_evaluate("solid.maxDisp", "mm")
 ```
+
+### Pressure Acoustics in a 2D Duct
+
+```
+# 1. Create a 2D model and geometry
+model_create("acoustic_duct")
+model_create_component(component_name="comp1", space_dimension=2)
+geometry_create(
+    geometry_name="geom1",
+    space_dimension=2,
+    component_name="comp1"
+)
+
+param_set("duct_length", "1[m]")
+param_set("duct_height", "0.1[m]")
+param_set("inlet_velocity", "0.01[m/s]")
+
+geometry_add_rectangle(
+    position=[0, 0],
+    size=["duct_length", "duct_height"],
+    geometry_name="geom1",
+    component_name="comp1"
+)
+geometry_build(geometry_name="geom1")
+
+# 2. Create stable side selections
+geometry_create_side_selections(
+    x_min="0[m]",
+    x_max="duct_length",
+    y_min="0[m]",
+    y_max="duct_height",
+    prefix="duct",
+    entity_dimension=1,
+    geometry_name="geom1",
+    component_name="comp1"
+)
+
+# 3. Add physics and configure boundaries
+physics_add_pressure_acoustics(
+    component_name="comp1",
+    geometry_name="geom1",
+    physics_tag="acpr"
+)
+
+boundary_result = physics_setup_acoustic_boundaries(
+    physics_name="acpr",
+    boundary_conditions=[
+        {
+            "type": "NormalVelocity",
+            "selection_name": "duct_left",
+            "properties": {"nvel": "inlet_velocity"}
+        },
+        {
+            "type": "PlaneWaveRadiation",
+            "selection_name": "duct_right"
+        },
+        {
+            "type": "SoundHard",
+            "selection_name": "duct_bottom"
+        },
+        {
+            "type": "SoundHard",
+            "selection_name": "duct_top"
+        }
+    ]
+)
+
+# Check failed_count and failed_boundaries before solving
+
+# 4. Mesh and frequency-domain study
+mesh_create(
+    mesh_name="mesh1",
+    geometry_name="geom1",
+    component_name="comp1"
+)
+study_create(study_type="Frequency", study_name="std1")
+study_solve(study_name="std1")
+```
+
+The actual frequency list and material properties must be configured for the
+specific model. Acoustic feature types and result expressions can vary by
+COMSOL version.
+
+### Coefficient Form PDE with Named Boundaries
+
+```
+# 1. Create a 2D PDE domain
+model_create("coefficient_pde")
+model_create_component(component_name="comp1", space_dimension=2)
+geometry_create(
+    geometry_name="geom1",
+    space_dimension=2,
+    component_name="comp1"
+)
+
+param_set("domain_width", "1[m]")
+param_set("domain_height", "1[m]")
+param_set("source", "1")
+
+geometry_add_rectangle(
+    position=[0, 0],
+    size=["domain_width", "domain_height"],
+    geometry_name="geom1",
+    component_name="comp1"
+)
+geometry_build(geometry_name="geom1")
+
+# 2. Create named selections
+geometry_create_side_selections(
+    x_min="0[m]",
+    x_max="domain_width",
+    y_min="0[m]",
+    y_max="domain_height",
+    prefix="domain",
+    entity_dimension=1,
+    geometry_name="geom1",
+    component_name="comp1"
+)
+
+# 3. Add the PDE and its equation coefficients
+pde_result = physics_add_coefficient_form_pde(
+    dependent_variables=["u"],
+    equation_properties={
+        "c": "1",
+        "a": "0",
+        "f": "source",
+        "da": "0",
+        "ea": "0"
+    },
+    physics_tag="c"
+)
+
+# Check property_errors before continuing
+
+# 4. Configure PDE boundaries
+boundary_result = physics_setup_pde_boundaries(
+    physics_name="c",
+    boundary_conditions=[
+        {
+            "type": "dirichlet",
+            "selection_name": "domain_left",
+            "properties": {"r": "0"}
+        },
+        {
+            "type": "dirichlet",
+            "selection_name": "domain_right",
+            "properties": {"r": "1"}
+        },
+        {
+            "type": "zero_flux",
+            "selection_name": "domain_bottom"
+        },
+        {
+            "type": "zero_flux",
+            "selection_name": "domain_top"
+        }
+    ]
+)
+
+# Check failed_count and failed_boundaries before solving
+
+# 5. Mesh, solve, and evaluate
+mesh_create(
+    mesh_name="mesh1",
+    geometry_name="geom1",
+    component_name="comp1"
+)
+study_create(study_type="Stationary", study_name="std1")
+study_solve(study_name="std1")
+results_evaluate("u")
+```
+
+For General Form PDE, replace the add call with
+`physics_add_general_form_pde` and configure `Ga`, `f`, `da`, and `ea`. For
+Weak Form PDE, use `physics_add_weak_form_pde` and set the `weak` equation
+property. Boundary selection and mesh steps remain the same.
 
 ### Parametric Sweep
 

--- a/src/tools/geometry.py
+++ b/src/tools/geometry.py
@@ -695,3 +695,200 @@ def register_geometry_tools(mcp: FastMCP) -> None:
             }
         except Exception as e:
             return {"success": False, "error": f"Failed to list features: {str(e)}"}
+
+    @mcp.tool()
+    def geometry_create_box_selection(
+        selection_name: str,
+        x_min: str,
+        x_max: str,
+        y_min: str,
+        y_max: str,
+        z_min: Optional[str] = None,
+        z_max: Optional[str] = None,
+        entity_dimension: int = 1,
+        condition: str = "intersects",
+        geometry_name: Optional[str] = None,
+        component_name: str = "comp1",
+        model_name: Optional[str] = None
+    ) -> dict:
+        """
+        Create a named Box selection for geometry entities by position.
+
+        For a 2D model, use entity_dimension=1 to select boundaries. For a 3D
+        model, use entity_dimension=2 to select boundary faces.
+
+        Args:
+            selection_name: Stable selection tag
+            x_min: Minimum x-coordinate expression
+            x_max: Maximum x-coordinate expression
+            y_min: Minimum y-coordinate expression
+            y_max: Maximum y-coordinate expression
+            z_min: Optional minimum z-coordinate expression
+            z_max: Optional maximum z-coordinate expression
+            entity_dimension: Entity dimension (default: 1)
+            condition: Box condition, usually "intersects" or "inside"
+            geometry_name: Geometry sequence tag (default: first geometry)
+            component_name: Component name (default: "comp1")
+            model_name: Model name (default: current model)
+
+        Returns:
+            Created named selection and matched entity numbers when available
+        """
+        model = session_manager.get_model(model_name)
+        if model is None:
+            return {
+                "success": False,
+                "error": f"Model not found: {model_name or 'no current model'}"
+            }
+
+        try:
+            jm = model.java
+            comp = jm.component(component_name)
+            if comp is None:
+                return {
+                    "success": False,
+                    "error": f"Component not found: {component_name}"
+                }
+
+            if geometry_name:
+                geom_tag = geometry_name
+            else:
+                geometries = comp.geom()
+                if geometries.size() == 0:
+                    return {
+                        "success": False,
+                        "error": "No geometry sequences found."
+                    }
+                geom_tag = str(geometries.tags()[0])
+
+            selection = comp.selection().create(selection_name, "Box")
+            selection.geom(geom_tag, int(entity_dimension))
+            selection.set("xmin", x_min)
+            selection.set("xmax", x_max)
+            selection.set("ymin", y_min)
+            selection.set("ymax", y_max)
+            if z_min is not None:
+                selection.set("zmin", z_min)
+            if z_max is not None:
+                selection.set("zmax", z_max)
+            selection.set("condition", condition)
+
+            result = {
+                "success": True,
+                "selection": {
+                    "tag": selection_name,
+                    "type": "Box",
+                    "component": component_name,
+                    "geometry": geom_tag,
+                    "entity_dimension": int(entity_dimension),
+                    "condition": condition,
+                    "bounds": {
+                        "x_min": x_min,
+                        "x_max": x_max,
+                        "y_min": y_min,
+                        "y_max": y_max,
+                    },
+                },
+            }
+            if z_min is not None or z_max is not None:
+                result["selection"]["bounds"].update({
+                    "z_min": z_min,
+                    "z_max": z_max,
+                })
+
+            try:
+                result["selection"]["entities"] = [
+                    int(entity) for entity in selection.entities()
+                ]
+            except Exception as e:
+                result["selection"]["entities"] = []
+                result["warning"] = (
+                    "Selection created, but entities could not be evaluated. "
+                    f"Build the geometry first. Details: {str(e)}"
+                )
+
+            return result
+        except Exception as e:
+            return {
+                "success": False,
+                "error": f"Failed to create box selection: {str(e)}"
+            }
+
+    @mcp.tool()
+    def geometry_create_side_selections(
+        x_min: str,
+        x_max: str,
+        y_min: str,
+        y_max: str,
+        prefix: str = "side",
+        tolerance: str = "1e-9[m]",
+        entity_dimension: int = 1,
+        geometry_name: Optional[str] = None,
+        component_name: str = "comp1",
+        model_name: Optional[str] = None
+    ) -> dict:
+        """
+        Create named left, right, bottom, and top Box selections.
+
+        This is intended for rectangular 2D domains such as waveguides and
+        water-wave tanks. The resulting tags are <prefix>_left,
+        <prefix>_right, <prefix>_bottom, and <prefix>_top.
+        """
+        expanded_x_min = f"({x_min})-({tolerance})"
+        expanded_x_max = f"({x_max})+({tolerance})"
+        expanded_y_min = f"({y_min})-({tolerance})"
+        expanded_y_max = f"({y_max})+({tolerance})"
+
+        definitions = {
+            "left": {
+                "x_min": expanded_x_min,
+                "x_max": f"({x_min})+({tolerance})",
+                "y_min": expanded_y_min,
+                "y_max": expanded_y_max,
+            },
+            "right": {
+                "x_min": f"({x_max})-({tolerance})",
+                "x_max": expanded_x_max,
+                "y_min": expanded_y_min,
+                "y_max": expanded_y_max,
+            },
+            "bottom": {
+                "x_min": expanded_x_min,
+                "x_max": expanded_x_max,
+                "y_min": expanded_y_min,
+                "y_max": f"({y_min})+({tolerance})",
+            },
+            "top": {
+                "x_min": expanded_x_min,
+                "x_max": expanded_x_max,
+                "y_min": f"({y_max})-({tolerance})",
+                "y_max": expanded_y_max,
+            },
+        }
+
+        created = {}
+        failed = {}
+        for side, bounds in definitions.items():
+            selection_tag = f"{prefix}_{side}"
+            result = geometry_create_box_selection(
+                selection_name=selection_tag,
+                entity_dimension=entity_dimension,
+                condition="intersects",
+                geometry_name=geometry_name,
+                component_name=component_name,
+                model_name=model_name,
+                **bounds,
+            )
+            if result.get("success"):
+                created[side] = result["selection"]
+            else:
+                failed[side] = result.get("error", "Unknown error")
+
+        return {
+            "success": not failed,
+            "prefix": prefix,
+            "selections": created,
+            "failed_selections": failed,
+            "created_count": len(created),
+            "failed_count": len(failed),
+        }

--- a/src/tools/mesh.py
+++ b/src/tools/mesh.py
@@ -1,24 +1,65 @@
 """Mesh tools for COMSOL MCP Server."""
 
 from typing import Optional
+
 from mcp.server.fastmcp import FastMCP
 
 from .session import session_manager
 
 
+def _get_component_java(java_model, component_name=None):
+    """Return an explicit component or the model's first component."""
+    if component_name:
+        return java_model.component(component_name)
+    components = java_model.component()
+    if components.size() == 0:
+        raise ValueError("No components defined in the model.")
+    return java_model.component(str(components.tags()[0]))
+
+
+def _get_geometry_tag(component, geometry_name=None):
+    """Return an explicit geometry tag or the component's first geometry."""
+    if geometry_name:
+        return geometry_name
+    geometries = component.geom()
+    if geometries.size() == 0:
+        raise ValueError("No geometries defined in the component.")
+    return str(geometries.tags()[0])
+
+
+def _mesh_tags(component):
+    """Return stable Java tags for all mesh sequences in a component."""
+    return [str(tag) for tag in component.mesh().tags()]
+
+
+def _safe_label(java_node):
+    """Return a usable label without leaking Java replacement characters."""
+    try:
+        label = java_node.label()
+        if label and "\ufffd" not in label:
+            return str(label)
+    except Exception:
+        pass
+    return None
+
+
 def register_mesh_tools(mcp: FastMCP) -> None:
     """Register mesh tools with the MCP server."""
-    
+
     @mcp.tool()
-    def mesh_list(model_name: Optional[str] = None) -> dict:
+    def mesh_list(
+        component_name: Optional[str] = None,
+        model_name: Optional[str] = None
+    ) -> dict:
         """
-        List all mesh sequences in a model.
-        
+        List mesh sequences by stable COMSOL Java tag.
+
         Args:
+            component_name: Component name (default: all components)
             model_name: Model name (default: current model)
-        
+
         Returns:
-            List of mesh sequence names
+            Mesh sequence tags, components, and usable labels
         """
         model = session_manager.get_model(model_name)
         if model is None:
@@ -26,31 +67,111 @@ def register_mesh_tools(mcp: FastMCP) -> None:
                 "success": False,
                 "error": f"Model not found: {model_name or 'no current model'}"
             }
-        
+
         try:
-            meshes = model.meshes()
+            java_model = model.java
+            components = java_model.component()
+            mesh_items = []
+
+            for component_tag in components.tags():
+                comp = java_model.component(str(component_tag))
+                if component_name and comp.tag() != component_name:
+                    continue
+                for mesh_tag in comp.mesh().tags():
+                    java_mesh = comp.mesh(str(mesh_tag))
+                    item = {
+                        "tag": str(java_mesh.tag()),
+                        "component": str(comp.tag()),
+                    }
+                    label = _safe_label(java_mesh)
+                    if label:
+                        item["label"] = label
+                    mesh_items.append(item)
+
+            if component_name and not any(
+                item["component"] == component_name for item in mesh_items
+            ):
+                _get_component_java(java_model, component_name)
+
             return {
                 "success": True,
-                "meshes": meshes,
-                "count": len(meshes),
+                "meshes": mesh_items,
+                "count": len(mesh_items),
             }
         except Exception as e:
             return {"success": False, "error": f"Failed to list meshes: {str(e)}"}
-    
+
     @mcp.tool()
-    def mesh_create(
-        mesh_name: Optional[str] = None,
+    def mesh_create_sequence(
+        mesh_name: str = "mesh1",
+        geometry_name: Optional[str] = None,
+        component_name: Optional[str] = None,
         model_name: Optional[str] = None
     ) -> dict:
         """
-        Run a mesh sequence to generate the mesh.
-        
-        This executes the meshing operations defined in the mesh sequence.
-        
+        Create a mesh sequence bound to a geometry.
+
         Args:
-            mesh_name: Mesh sequence name (default: run all mesh sequences)
+            mesh_name: Mesh sequence tag (default: "mesh1")
+            geometry_name: Geometry sequence tag (default: first geometry)
+            component_name: Component name (default: first component)
             model_name: Model name (default: current model)
-        
+
+        Returns:
+            Created mesh sequence info
+        """
+        model = session_manager.get_model(model_name)
+        if model is None:
+            return {
+                "success": False,
+                "error": f"Model not found: {model_name or 'no current model'}"
+            }
+
+        try:
+            comp = _get_component_java(model.java, component_name)
+            existing_tags = _mesh_tags(comp)
+            if mesh_name in existing_tags:
+                return {
+                    "success": False,
+                    "error": f"Mesh sequence already exists: {mesh_name}",
+                    "available_meshes": existing_tags,
+                }
+
+            geom_tag = _get_geometry_tag(comp, geometry_name)
+            java_mesh = comp.mesh().create(mesh_name, geom_tag)
+
+            return {
+                "success": True,
+                "mesh": {
+                    "tag": str(java_mesh.tag()),
+                    "component": str(comp.tag()),
+                    "geometry": geom_tag,
+                },
+            }
+        except Exception as e:
+            return {
+                "success": False,
+                "error": f"Failed to create mesh sequence: {str(e)}"
+            }
+
+    @mcp.tool()
+    def mesh_create(
+        mesh_name: Optional[str] = None,
+        geometry_name: Optional[str] = None,
+        component_name: Optional[str] = None,
+        auto_create: bool = True,
+        model_name: Optional[str] = None
+    ) -> dict:
+        """
+        Run one or all mesh sequences, creating a default sequence when needed.
+
+        Args:
+            mesh_name: Mesh sequence tag (default: all, or "mesh1" when created)
+            geometry_name: Geometry tag used when creating a mesh sequence
+            component_name: Component name (default: first component)
+            auto_create: Create a missing mesh sequence (default: True)
+            model_name: Model name (default: current model)
+
         Returns:
             Mesh generation status
         """
@@ -60,31 +181,67 @@ def register_mesh_tools(mcp: FastMCP) -> None:
                 "success": False,
                 "error": f"Model not found: {model_name or 'no current model'}"
             }
-        
+
         try:
-            model.mesh(mesh_name)
+            java_model = model.java
+            comp = _get_component_java(java_model, component_name)
+            mesh_tags = _mesh_tags(comp)
+            created_sequence = False
+
+            if mesh_name:
+                target_tags = [mesh_name]
+                if mesh_name not in mesh_tags:
+                    if not auto_create:
+                        return {
+                            "success": False,
+                            "error": f"Mesh sequence not found: {mesh_name}",
+                            "available_meshes": mesh_tags,
+                        }
+                    geom_tag = _get_geometry_tag(comp, geometry_name)
+                    comp.mesh().create(mesh_name, geom_tag)
+                    created_sequence = True
+            elif mesh_tags:
+                target_tags = mesh_tags
+            elif auto_create:
+                geom_tag = _get_geometry_tag(comp, geometry_name)
+                comp.mesh().create("mesh1", geom_tag)
+                target_tags = ["mesh1"]
+                created_sequence = True
+            else:
+                return {
+                    "success": False,
+                    "error": "No mesh sequences defined in the model.",
+                }
+
+            for target_tag in target_tags:
+                comp.mesh(target_tag).run()
+
             return {
                 "success": True,
-                "mesh": mesh_name,
-                "message": f"Mesh created: {mesh_name or 'all meshes'}",
+                "meshes": target_tags,
+                "component": str(comp.tag()),
+                "auto_created": created_sequence,
+                "message": f"Mesh created: {', '.join(target_tags)}",
             }
         except Exception as e:
             return {"success": False, "error": f"Failed to create mesh: {str(e)}"}
-    
+
     @mcp.tool()
     def mesh_info(
         mesh_name: Optional[str] = None,
+        component_name: Optional[str] = None,
         model_name: Optional[str] = None
     ) -> dict:
         """
-        Get information about a mesh.
-        
+        Get mesh information using a stable Java tag.
+
         Args:
-            mesh_name: Mesh sequence name (default: first mesh)
+            mesh_name: Mesh sequence tag (default: first mesh)
+            component_name: Component name (default: first component)
             model_name: Model name (default: current model)
-        
+
         Returns:
-            Mesh statistics including element counts
+            Mesh tag, component, geometry, and feature information
         """
         model = session_manager.get_model(model_name)
         if model is None:
@@ -92,40 +249,51 @@ def register_mesh_tools(mcp: FastMCP) -> None:
                 "success": False,
                 "error": f"Model not found: {model_name or 'no current model'}"
             }
-        
+
         try:
-            meshes = model.meshes()
-            if not meshes:
+            comp = _get_component_java(model.java, component_name)
+            mesh_tags = _mesh_tags(comp)
+            if not mesh_tags:
                 return {"success": False, "error": "No meshes defined in model."}
-            
-            target = mesh_name or meshes[0]
-            if target not in meshes:
-                return {"success": False, "error": f"Mesh not found: {target}"}
-            
-            mesh_node = model / "meshes" / target
-            
+
+            target_tag = mesh_name or mesh_tags[0]
+            if target_tag not in mesh_tags:
+                return {
+                    "success": False,
+                    "error": f"Mesh not found: {target_tag}",
+                    "available_meshes": mesh_tags,
+                }
+
+            java_mesh = comp.mesh(target_tag)
+            features = []
+            feature_list = java_mesh.feature()
+            for feature_tag in feature_list.tags():
+                feature = java_mesh.feature(str(feature_tag))
+                feature_info = {"tag": str(feature.tag())}
+                try:
+                    feature_info["type"] = str(feature.getType())
+                except Exception:
+                    pass
+                label = _safe_label(feature)
+                if label:
+                    feature_info["label"] = label
+                features.append(feature_info)
+
             info = {
-                "name": target,
+                "tag": target_tag,
+                "component": str(comp.tag()),
+                "features": features,
+                "feature_count": len(features),
             }
-            
+            label = _safe_label(java_mesh)
+            if label:
+                info["label"] = label
+
             try:
-                java_mesh = mesh_node.java
-                if hasattr(java_mesh, 'getVertex'):
-                    info["num_vertices"] = java_mesh.getVertex().size()
-                if hasattr(java_mesh, 'getElement'):
-                    info["num_elements"] = java_mesh.getElement().size()
+                info["geometry"] = str(java_mesh.geom())
             except Exception:
                 pass
-            
-            try:
-                children = [child.name() for child in mesh_node.children()]
-                info["features"] = children
-            except Exception:
-                pass
-            
-            return {
-                "success": True,
-                "mesh": info,
-            }
+
+            return {"success": True, "mesh": info}
         except Exception as e:
             return {"success": False, "error": f"Failed to get mesh info: {str(e)}"}

--- a/src/tools/physics.py
+++ b/src/tools/physics.py
@@ -8,14 +8,30 @@ from .session import session_manager
 _tag_counter = {}
 
 
+def _get_component_java(java_model, component_name=None):
+    """Return an explicit component or the model's first component by tag."""
+    if component_name:
+        return java_model.component(component_name)
+    components = java_model.component()
+    if components.size() == 0:
+        raise ValueError("No components defined in the model.")
+    return java_model.component(str(components.tags()[0]))
+
+
 def _find_physics_java(jm, physics_name):
     """Look up a physics node by label or tag across all components."""
-    for i in range(jm.component().size()):
-        comp = jm.component().get(i)
-        for j in range(comp.physics().size()):
-            p = comp.physics().get(j)
+    context = _find_physics_context(jm, physics_name)
+    return context[1] if context else None
+
+
+def _find_physics_context(jm, physics_name):
+    """Look up the component and physics node by label or tag."""
+    for component_tag in jm.component().tags():
+        comp = jm.component(str(component_tag))
+        for physics_tag in comp.physics().tags():
+            p = comp.physics(str(physics_tag))
             if p.label() == physics_name or p.tag() == physics_name:
-                return p
+                return comp, p
     return None
 
 
@@ -23,6 +39,126 @@ def _make_tag(prefix="bc"):
     """Generate a unique tag using a monotonic counter."""
     _tag_counter[prefix] = _tag_counter.get(prefix, 0) + 1
     return f"{prefix}_{_tag_counter[prefix]}"
+
+
+def _set_feature_properties(feature, properties):
+    """Set feature properties and return any failures without hiding them."""
+    failures = {}
+    for prop_name, prop_value in properties.items():
+        try:
+            feature.set(prop_name, prop_value)
+        except Exception as e:
+            failures[prop_name] = str(e)
+    return failures
+
+
+def _set_domain_selection(physics_java, domain_selection):
+    """Apply an optional explicit domain selection to a physics interface."""
+    if domain_selection:
+        physics_java.selection().set([int(d) for d in domain_selection])
+
+
+def _get_geometry_tag(component, geometry_name=None):
+    """Resolve an explicit geometry tag or the component's first geometry."""
+    if geometry_name:
+        return geometry_name
+    geometries = component.geom()
+    if geometries.size() == 0:
+        raise ValueError("No geometry found in component.")
+    return str(geometries.tags()[0])
+
+
+def _get_boundary_dimension(component, boundary_dimension=None):
+    """Resolve a boundary dimension from input or the first component geometry."""
+    if boundary_dimension is not None:
+        return int(boundary_dimension)
+    geometries = component.geom()
+    if geometries.size() == 0:
+        raise ValueError("No geometry found in component.")
+    geom_tag = str(geometries.tags()[0])
+    return int(component.geom(geom_tag).getSDim()) - 1
+
+
+def _create_boundary_features(
+    physics_java,
+    physics_name,
+    boundary_conditions,
+    boundary_dimension,
+):
+    """Create a batch of boundary features from a common configuration format."""
+    created = []
+    failed = []
+
+    for index, condition in enumerate(boundary_conditions):
+        condition_type = condition.get("type") or condition.get("boundary_condition")
+        boundaries = condition.get("boundaries") or condition.get("boundary_selection")
+        selection_name = condition.get("selection_name")
+        properties = condition.get("properties") or {}
+
+        if not condition_type:
+            failed.append({"index": index, "error": "Missing boundary condition type."})
+            continue
+        if not boundaries and not selection_name:
+            failed.append({
+                "index": index,
+                "type": condition_type,
+                "error": "Missing boundary selection or selection name.",
+            })
+            continue
+
+        tag = condition.get("tag") or _make_tag(condition_type.lower())
+        dimension = condition.get("dimension", boundary_dimension)
+        try:
+            feature = physics_java.create(tag, condition_type, int(dimension))
+            if selection_name:
+                feature.selection().named(selection_name)
+            else:
+                feature.selection().set([int(b) for b in boundaries])
+            property_failures = _set_feature_properties(feature, properties)
+            label = condition.get("label")
+            if label:
+                feature.label(label)
+            elif selection_name:
+                feature.label(f'{condition_type} (Selection {selection_name})')
+            else:
+                feature.label(f'{condition_type} (Boundaries {list(boundaries)})')
+
+            result = {
+                "tag": tag,
+                "type": condition_type,
+                "dimension": int(dimension),
+                "properties": properties,
+            }
+            if selection_name:
+                result["selection_name"] = selection_name
+            else:
+                result["boundaries"] = list(boundaries)
+            if property_failures:
+                result["property_errors"] = property_failures
+                failed.append(result)
+            else:
+                created.append(result)
+        except Exception as e:
+            failed.append({
+                "index": index,
+                "tag": tag,
+                "type": condition_type,
+                "dimension": int(dimension),
+                "error": str(e),
+            })
+            if selection_name:
+                failed[-1]["selection_name"] = selection_name
+            elif boundaries:
+                failed[-1]["boundaries"] = list(boundaries)
+
+    return {
+        "success": not failed,
+        "physics": physics_name,
+        "configured_boundaries": created,
+        "failed_boundaries": failed,
+        "configured_count": len(created),
+        "failed_count": len(failed),
+    }
 
 
 PHYSICS_INTERFACES = {
@@ -52,6 +188,11 @@ PHYSICS_INTERFACES = {
         "pressure_acoustics": "Pressure Acoustics (acpr)",
         "thermoacoustics": "Thermoacoustics (ta)",
     },
+    "Mathematics": {
+        "coefficient_form_pde": "Coefficient Form PDE (c)",
+        "general_form_pde": "General Form PDE (g)",
+        "weak_form_pde": "Weak Form PDE (w)",
+    },
     "Chemical": {
         "transport_diluted": "Transport of Diluted Species (tds)",
         "reaction_engineering": "Reaction Engineering (re)",
@@ -66,6 +207,75 @@ PHYSICS_INTERFACES = {
         "electromechanical": "Electromechanical Forces",
         "joule_heating": "Joule Heating (jh)",
     },
+}
+
+ACOUSTIC_BOUNDARY_CONDITIONS = {
+    "SoundHard": {
+        "description": "Sound hard wall; no user property is normally required.",
+        "properties": [],
+    },
+    "SoundSoft": {
+        "description": "Sound soft boundary with zero acoustic pressure.",
+        "properties": [],
+    },
+    "Pressure": {
+        "description": "Prescribed acoustic pressure.",
+        "properties": ["p0"],
+    },
+    "Impedance": {
+        "description": "Specific acoustic impedance boundary.",
+        "properties": ["Zn"],
+    },
+    "NormalAcceleration": {
+        "description": "Prescribed normal acceleration source.",
+        "properties": ["nacc"],
+    },
+    "NormalVelocity": {
+        "description": "Prescribed normal velocity source.",
+        "properties": ["nvel"],
+    },
+    "PlaneWaveRadiation": {
+        "description": "Nonreflecting plane-wave radiation boundary.",
+        "properties": [],
+    },
+    "SphericalWaveRadiation": {
+        "description": "Nonreflecting spherical-wave radiation boundary.",
+        "properties": [],
+    },
+}
+
+PDE_BOUNDARY_CONDITIONS = {
+    "DirichletBoundary": {
+        "description": "Prescribed dependent-variable value.",
+        "properties": ["r"],
+    },
+    "FluxBoundary": {
+        "description": "Prescribed generalized inward flux/source.",
+        "properties": ["g", "q"],
+    },
+    "ZeroFluxBoundary": {
+        "description": "Zero inward flux boundary condition.",
+        "properties": [],
+    },
+    "WeakContribution": {
+        "description": "Weak contribution on selected boundaries.",
+        "properties": ["weak"],
+    },
+    "PeriodicCondition": {
+        "description": "Periodic boundary condition.",
+        "properties": [],
+    },
+}
+
+PDE_BOUNDARY_ALIASES = {
+    "dirichlet": "DirichletBoundary",
+    "flux": "FluxBoundary",
+    "neumann": "FluxBoundary",
+    "zero_flux": "ZeroFluxBoundary",
+    "no_flux": "ZeroFluxBoundary",
+    "wall": "ZeroFluxBoundary",
+    "weak": "WeakContribution",
+    "periodic": "PeriodicCondition",
 }
 
 
@@ -117,6 +327,43 @@ def register_physics_tools(mcp: FastMCP) -> None:
             "interfaces": PHYSICS_INTERFACES,
             "note": "Interface identifiers (in parentheses) are used when adding physics.",
         }
+
+    @mcp.tool()
+    def physics_get_acoustic_boundary_conditions() -> dict:
+        """
+        Get common Pressure Acoustics boundary feature types and properties.
+
+        Returns:
+            Acoustic boundary condition reference
+        """
+        return {
+            "success": True,
+            "boundary_conditions": ACOUSTIC_BOUNDARY_CONDITIONS,
+            "note": (
+                "Feature types and properties can vary by acoustic interface and "
+                "COMSOL version. Custom feature types remain available through "
+                "physics_configure_acoustic_boundary."
+            ),
+        }
+
+    @mcp.tool()
+    def physics_get_pde_boundary_conditions() -> dict:
+        """
+        Get common PDE boundary feature types and properties.
+
+        Returns:
+            PDE boundary condition reference
+        """
+        return {
+            "success": True,
+            "boundary_conditions": PDE_BOUNDARY_CONDITIONS,
+            "aliases": PDE_BOUNDARY_ALIASES,
+            "note": (
+                "PDE property values can be scalars, vectors, or matrices depending "
+                "on the number of dependent variables. Custom feature types remain "
+                "available through physics_configure_pde_boundary."
+            ),
+        }
     
     @mcp.tool()
     def physics_add(
@@ -155,7 +402,7 @@ def register_physics_tools(mcp: FastMCP) -> None:
             if component_name:
                 comp = jm.component(component_name)
             else:
-                comp = jm.component().get(0)
+                comp = _get_component_java(jm)
 
             if comp is None:
                 return {"success": False, "error": f"Component not found: {component_name}"}
@@ -199,7 +446,7 @@ def register_physics_tools(mcp: FastMCP) -> None:
 
         try:
             jm = model.java
-            comp = jm.component().get(0)
+            comp = _get_component_java(jm)
             physics_java = comp.physics().create("es", "Electrostatics")
 
             if domain_selection:
@@ -244,7 +491,7 @@ def register_physics_tools(mcp: FastMCP) -> None:
 
         try:
             jm = model.java
-            comp = jm.component().get(0)
+            comp = _get_component_java(jm)
             physics_java = comp.physics().create("solid", "SolidMechanics")
 
             if domain_selection:
@@ -289,7 +536,7 @@ def register_physics_tools(mcp: FastMCP) -> None:
 
         try:
             jm = model.java
-            comp = jm.component().get(0)
+            comp = _get_component_java(jm)
             physics_java = comp.physics().create("ht", "HeatTransfer")
 
             if domain_selection:
@@ -334,7 +581,7 @@ def register_physics_tools(mcp: FastMCP) -> None:
 
         try:
             jm = model.java
-            comp = jm.component().get(0)
+            comp = _get_component_java(jm)
             physics_java = comp.physics().create("spf", "LaminarFlow")
 
             if domain_selection:
@@ -354,6 +601,286 @@ def register_physics_tools(mcp: FastMCP) -> None:
             }
         except Exception as e:
             return {"success": False, "error": f"Failed to add Laminar Flow: {str(e)}"}
+
+    @mcp.tool()
+    def physics_add_pressure_acoustics(
+        domain_selection: Optional[Sequence[int]] = None,
+        component_name: Optional[str] = None,
+        geometry_name: Optional[str] = None,
+        physics_tag: str = "acpr",
+        model_name: Optional[str] = None
+    ) -> dict:
+        """
+        Add Pressure Acoustics physics for frequency-domain acoustic analysis.
+
+        Args:
+            domain_selection: Domain numbers (default: all domains)
+            component_name: Component to add physics to (default: first component)
+            geometry_name: Geometry sequence tag (default: first geometry)
+            physics_tag: Physics interface tag (default: "acpr")
+            model_name: Model name (default: current model)
+
+        Returns:
+            Created physics info
+        """
+        model = session_manager.get_model(model_name)
+        if model is None:
+            return {
+                "success": False,
+                "error": f"Model not found: {model_name or 'no current model'}"
+            }
+
+        try:
+            jm = model.java
+            comp = _get_component_java(jm, component_name)
+            geom_tag = _get_geometry_tag(comp, geometry_name)
+            physics_java = comp.physics().create(
+                physics_tag,
+                "PressureAcoustics",
+                geom_tag,
+            )
+            _set_domain_selection(physics_java, domain_selection)
+
+            return {
+                "success": True,
+                "physics": {
+                    "name": (
+                        physics_java.label()
+                        if hasattr(physics_java, 'label')
+                        else "Pressure Acoustics"
+                    ),
+                    "type": "PressureAcoustics",
+                    "tag": physics_tag,
+                    "component": comp.tag(),
+                    "geometry": geom_tag,
+                    "domain_selection": (
+                        list(domain_selection) if domain_selection else "all"
+                    ),
+                }
+            }
+        except Exception as e:
+            return {
+                "success": False,
+                "error": f"Failed to add Pressure Acoustics: {str(e)}"
+            }
+
+    @mcp.tool()
+    def physics_add_acoustics(
+        physics_type: str,
+        physics_tag: Optional[str] = None,
+        domain_selection: Optional[Sequence[int]] = None,
+        component_name: Optional[str] = None,
+        geometry_name: Optional[str] = None,
+        model_name: Optional[str] = None
+    ) -> dict:
+        """
+        Add a geometry-based Acoustics Module physics interface.
+
+        Use the exact COMSOL physics type for the installed version. Confirmed
+        COMSOL 6.3 examples include PressureAcoustics and
+        ThermoacousticsSinglePhysics. This tool also supports other acoustic
+        interface types without maintaining a hard-coded allowlist.
+
+        Args:
+            physics_type: Exact COMSOL acoustic physics type
+            physics_tag: Physics interface tag (default: generated from type)
+            domain_selection: Domain numbers (default: all domains)
+            component_name: Component to add physics to (default: first component)
+            geometry_name: Geometry sequence tag (default: first geometry)
+            model_name: Model name (default: current model)
+
+        Returns:
+            Created physics info
+        """
+        model = session_manager.get_model(model_name)
+        if model is None:
+            return {
+                "success": False,
+                "error": f"Model not found: {model_name or 'no current model'}"
+            }
+
+        tag = physics_tag or physics_type.replace(" ", "_").lower()
+
+        try:
+            jm = model.java
+            comp = _get_component_java(jm, component_name)
+            geom_tag = _get_geometry_tag(comp, geometry_name)
+            physics_java = comp.physics().create(tag, physics_type, geom_tag)
+            _set_domain_selection(physics_java, domain_selection)
+
+            return {
+                "success": True,
+                "physics": {
+                    "name": (
+                        physics_java.label()
+                        if hasattr(physics_java, 'label')
+                        else physics_type
+                    ),
+                    "type": physics_type,
+                    "tag": tag,
+                    "component": comp.tag(),
+                    "geometry": geom_tag,
+                    "domain_selection": (
+                        list(domain_selection) if domain_selection else "all"
+                    ),
+                },
+                "note": (
+                    "The physics type is passed directly to the COMSOL Java API; "
+                    "availability depends on installed products and licenses."
+                ),
+            }
+        except Exception as e:
+            return {
+                "success": False,
+                "error": f"Failed to add acoustic physics '{physics_type}': {str(e)}"
+            }
+
+    def _add_pde_interface(
+        physics_type,
+        default_tag,
+        equation_feature,
+        dependent_variables,
+        equation_properties,
+        domain_selection,
+        component_name,
+        physics_tag,
+        model_name,
+    ):
+        """Create and optionally configure a PDE interface."""
+        model = session_manager.get_model(model_name)
+        if model is None:
+            return {
+                "success": False,
+                "error": f"Model not found: {model_name or 'no current model'}"
+            }
+
+        variables = list(dependent_variables) if dependent_variables else ["u"]
+        tag = physics_tag or default_tag
+
+        try:
+            jm = model.java
+            comp = _get_component_java(jm, component_name)
+            physics_java = comp.physics().create(tag, physics_type, variables)
+            _set_domain_selection(physics_java, domain_selection)
+
+            property_failures = {}
+            if equation_properties:
+                equation = physics_java.feature(equation_feature)
+                property_failures = _set_feature_properties(
+                    equation,
+                    equation_properties,
+                )
+
+            result = {
+                "success": not property_failures,
+                "physics": {
+                    "name": (
+                        physics_java.label()
+                        if hasattr(physics_java, 'label')
+                        else physics_type
+                    ),
+                    "type": physics_type,
+                    "tag": tag,
+                    "component": comp.tag(),
+                    "dependent_variables": variables,
+                    "domain_selection": (
+                        list(domain_selection) if domain_selection else "all"
+                    ),
+                    "equation_properties": equation_properties or {},
+                }
+            }
+            if property_failures:
+                result["error"] = "One or more PDE equation properties were rejected."
+                result["property_errors"] = property_failures
+            return result
+        except Exception as e:
+            return {
+                "success": False,
+                "error": f"Failed to add {physics_type}: {str(e)}"
+            }
+
+    @mcp.tool()
+    def physics_add_coefficient_form_pde(
+        dependent_variables: Sequence[str] = ("u",),
+        equation_properties: Optional[dict] = None,
+        domain_selection: Optional[Sequence[int]] = None,
+        component_name: Optional[str] = None,
+        physics_tag: str = "c",
+        model_name: Optional[str] = None
+    ) -> dict:
+        """
+        Add a Coefficient Form PDE interface.
+
+        Common equation properties include c, a, f, da, ea, al, be, and
+        ga. Values can be scalar, vector, or matrix expressions.
+        Rejected properties are returned explicitly.
+        """
+        return _add_pde_interface(
+            "CoefficientFormPDE",
+            "c",
+            "cfeq1",
+            dependent_variables,
+            equation_properties,
+            domain_selection,
+            component_name,
+            physics_tag,
+            model_name,
+        )
+
+    @mcp.tool()
+    def physics_add_general_form_pde(
+        dependent_variables: Sequence[str] = ("u",),
+        equation_properties: Optional[dict] = None,
+        domain_selection: Optional[Sequence[int]] = None,
+        component_name: Optional[str] = None,
+        physics_tag: str = "g",
+        model_name: Optional[str] = None
+    ) -> dict:
+        """
+        Add a General Form PDE interface.
+
+        Common equation properties include Ga, f, da, and ea. Values can be
+        scalar, vector, or matrix expressions. Rejected properties are returned
+        explicitly.
+        """
+        return _add_pde_interface(
+            "GeneralFormPDE",
+            "g",
+            "gfeq1",
+            dependent_variables,
+            equation_properties,
+            domain_selection,
+            component_name,
+            physics_tag,
+            model_name,
+        )
+
+    @mcp.tool()
+    def physics_add_weak_form_pde(
+        dependent_variables: Sequence[str] = ("u",),
+        equation_properties: Optional[dict] = None,
+        domain_selection: Optional[Sequence[int]] = None,
+        component_name: Optional[str] = None,
+        physics_tag: str = "w",
+        model_name: Optional[str] = None
+    ) -> dict:
+        """
+        Add a Weak Form PDE interface.
+
+        Set the weak expression with equation_properties={"weak": "..."}.
+        Rejected properties are returned explicitly.
+        """
+        return _add_pde_interface(
+            "WeakFormPDE",
+            "w",
+            "wfeq1",
+            dependent_variables,
+            equation_properties,
+            domain_selection,
+            component_name,
+            physics_tag,
+            model_name,
+        )
     
     @mcp.tool()
     def physics_configure_boundary(
@@ -436,6 +963,209 @@ def register_physics_tools(mcp: FastMCP) -> None:
             }
         except Exception as e:
             return {"success": False, "error": f"Failed to configure boundary: {str(e)}"}
+
+    def _setup_specialized_boundaries(
+        physics_name,
+        boundary_conditions,
+        condition_reference,
+        boundary_dimension,
+        model_name,
+    ):
+        """Find a physics interface and create specialized boundary features."""
+        model = session_manager.get_model(model_name)
+        if model is None:
+            return {
+                "success": False,
+                "error": f"Model not found: {model_name or 'no current model'}"
+            }
+
+        try:
+            context = _find_physics_context(model.java, physics_name)
+            if context is None:
+                return {
+                    "success": False,
+                    "error": f"Physics interface not found: {physics_name}"
+                }
+            comp, physics_java = context
+            dimension = _get_boundary_dimension(comp, boundary_dimension)
+
+            result = _create_boundary_features(
+                physics_java,
+                physics_name,
+                boundary_conditions,
+                dimension,
+            )
+            custom_types = sorted({
+                condition_type
+                for condition in boundary_conditions
+                for condition_type in [
+                    condition.get("type") or condition.get("boundary_condition")
+                ]
+                if condition_type and condition_type not in condition_reference
+            })
+            if custom_types:
+                result["custom_condition_types"] = custom_types
+                result["note"] = (
+                    "Custom condition types were passed directly to the COMSOL "
+                    "Java API. Their availability depends on the selected physics "
+                    "interface, installed products, and COMSOL version."
+                )
+            return result
+        except Exception as e:
+            return {
+                "success": False,
+                "error": f"Failed to setup boundaries: {str(e)}"
+            }
+
+    @mcp.tool()
+    def physics_configure_acoustic_boundary(
+        physics_name: str,
+        boundary_condition: str,
+        boundary_selection: Optional[Sequence[int]] = None,
+        properties: Optional[dict] = None,
+        selection_name: Optional[str] = None,
+        boundary_dimension: Optional[int] = None,
+        model_name: Optional[str] = None
+    ) -> dict:
+        """
+        Configure one Pressure Acoustics boundary condition.
+
+        Common types are SoundHard, SoundSoft, Pressure, Impedance,
+        NormalAcceleration, NormalVelocity, PlaneWaveRadiation, and
+        SphericalWaveRadiation. Unknown types are passed through for other
+        acoustic interfaces and versions. Property-setting errors are returned
+        instead of being ignored.
+        """
+        return _setup_specialized_boundaries(
+            physics_name,
+            [{
+                "type": boundary_condition,
+                "boundaries": (
+                    list(boundary_selection) if boundary_selection else None
+                ),
+                "selection_name": selection_name,
+                "properties": properties or {},
+            }],
+            ACOUSTIC_BOUNDARY_CONDITIONS,
+            boundary_dimension,
+            model_name,
+        )
+
+    @mcp.tool()
+    def physics_setup_acoustic_boundaries(
+        physics_name: str,
+        boundary_conditions: Sequence[dict],
+        boundary_dimension: Optional[int] = None,
+        model_name: Optional[str] = None
+    ) -> dict:
+        """
+        Configure multiple acoustic boundary conditions in one call.
+
+        Each item accepts:
+        - type: COMSOL boundary feature type
+        - boundaries: List of boundary numbers
+        - selection_name: Optional named COMSOL selection instead of numbers
+        - properties: Optional COMSOL property dictionary
+        - dimension: Optional geometric entity dimension override
+        - tag: Optional explicit feature tag
+        - label: Optional display label
+
+        Example:
+            [
+                {"type": "SoundHard", "boundaries": [1, 2]},
+                {
+                    "type": "Impedance",
+                    "boundaries": [3],
+                    "properties": {"Zn": "rho0*c0"}
+                }
+            ]
+        """
+        return _setup_specialized_boundaries(
+            physics_name,
+            boundary_conditions,
+            ACOUSTIC_BOUNDARY_CONDITIONS,
+            boundary_dimension,
+            model_name,
+        )
+
+    @mcp.tool()
+    def physics_configure_pde_boundary(
+        physics_name: str,
+        boundary_condition: str,
+        boundary_selection: Optional[Sequence[int]] = None,
+        properties: Optional[dict] = None,
+        selection_name: Optional[str] = None,
+        boundary_dimension: Optional[int] = None,
+        model_name: Optional[str] = None
+    ) -> dict:
+        """
+        Configure one Coefficient, General, or Weak Form PDE boundary condition.
+
+        Common types are DirichletBoundary, FluxBoundary, ZeroFluxBoundary,
+        WeakContribution, and PeriodicCondition. Unknown types are passed
+        through for version-specific PDE features. Use selection_name to bind
+        the condition to a named geometric selection instead of entity numbers.
+        Property-setting errors are returned instead of being ignored.
+        """
+        condition_type = PDE_BOUNDARY_ALIASES.get(
+            boundary_condition.lower(),
+            boundary_condition,
+        )
+        return _setup_specialized_boundaries(
+            physics_name,
+            [{
+                "type": condition_type,
+                "boundaries": (
+                    list(boundary_selection) if boundary_selection else None
+                ),
+                "selection_name": selection_name,
+                "properties": properties or {},
+            }],
+            PDE_BOUNDARY_CONDITIONS,
+            boundary_dimension,
+            model_name,
+        )
+
+    @mcp.tool()
+    def physics_setup_pde_boundaries(
+        physics_name: str,
+        boundary_conditions: Sequence[dict],
+        boundary_dimension: Optional[int] = None,
+        model_name: Optional[str] = None
+    ) -> dict:
+        """
+        Configure multiple PDE boundary conditions in one call.
+
+        Each item accepts:
+        - type: COMSOL boundary feature type
+        - boundaries: List of boundary numbers
+        - selection_name: Optional named COMSOL selection instead of numbers
+        - properties: Optional scalar, vector, or matrix property dictionary
+        - dimension: Optional geometric entity dimension override
+        - tag: Optional explicit feature tag
+        - label: Optional display label
+        """
+        normalized_conditions = []
+        for condition in boundary_conditions:
+            normalized = dict(condition)
+            condition_type = (
+                normalized.get("type")
+                or normalized.get("boundary_condition")
+            )
+            if condition_type:
+                normalized["type"] = PDE_BOUNDARY_ALIASES.get(
+                    condition_type.lower(),
+                    condition_type,
+                )
+            normalized_conditions.append(normalized)
+
+        return _setup_specialized_boundaries(
+            physics_name,
+            normalized_conditions,
+            PDE_BOUNDARY_CONDITIONS,
+            boundary_dimension,
+            model_name,
+        )
     
     @mcp.tool()
     def physics_set_material(
@@ -472,7 +1202,7 @@ def register_physics_tools(mcp: FastMCP) -> None:
             tag = material_name.replace(" ", "_").replace("-", "_")
 
             if material_name not in materials:
-                comp = jm.component().get(0)
+                comp = _get_component_java(jm)
                 try:
                     mat = comp.material().create(tag, "Common")
                     mat.label(material_name)

--- a/tests/test_mesh_and_selections.py
+++ b/tests/test_mesh_and_selections.py
@@ -1,0 +1,213 @@
+"""Tests for mesh sequence and geometry selection tools."""
+
+from src.tools import geometry, mesh
+
+
+class FakeMCP:
+    def __init__(self):
+        self.tools = {}
+
+    def tool(self):
+        def decorator(function):
+            self.tools[function.__name__] = function
+            return function
+
+        return decorator
+
+
+class FakeNodeList:
+    def __init__(self, items=None):
+        self.items = list(items or [])
+
+    def size(self):
+        return len(self.items)
+
+    def get(self, index):
+        return self.items[index]
+
+    def tags(self):
+        return [item.tag() for item in self.items]
+
+
+class FakeGeometry:
+    def __init__(self, tag="geom1"):
+        self._tag = tag
+
+    def tag(self):
+        return self._tag
+
+
+class FakeMesh:
+    def __init__(self, tag, geometry):
+        self._tag = tag
+        self._geometry = geometry
+        self.ran = False
+        self._features = FakeNodeList()
+
+    def tag(self):
+        return self._tag
+
+    def label(self):
+        return f"Mesh {self._tag}"
+
+    def geom(self):
+        return self._geometry
+
+    def run(self):
+        self.ran = True
+
+    def feature(self):
+        return self._features
+
+
+class FakeMeshList(FakeNodeList):
+    def create(self, tag, geometry):
+        item = FakeMesh(tag, geometry)
+        self.items.append(item)
+        return item
+
+
+class FakeBoxSelection:
+    def __init__(self, tag):
+        self._tag = tag
+        self.geometry = None
+        self.dimension = None
+        self.properties = {}
+
+    def geom(self, geometry, dimension):
+        self.geometry = geometry
+        self.dimension = dimension
+
+    def set(self, name, value):
+        self.properties[name] = value
+
+    def entities(self):
+        return [1, 2]
+
+
+class FakeSelectionList:
+    def __init__(self):
+        self.items = {}
+
+    def create(self, tag, selection_type):
+        assert selection_type == "Box"
+        item = FakeBoxSelection(tag)
+        self.items[tag] = item
+        return item
+
+
+class FakeComponent:
+    def __init__(self, tag="comp1"):
+        self._tag = tag
+        self._geometries = FakeNodeList([FakeGeometry()])
+        self._meshes = FakeMeshList()
+        self._selections = FakeSelectionList()
+
+    def tag(self):
+        return self._tag
+
+    def geom(self, tag=None):
+        if tag is None:
+            return self._geometries
+        return next(item for item in self._geometries.items if item.tag() == tag)
+
+    def mesh(self, tag=None):
+        if tag is None:
+            return self._meshes
+        return next(item for item in self._meshes.items if item.tag() == tag)
+
+    def selection(self):
+        return self._selections
+
+
+class FakeComponentList(FakeNodeList):
+    def __call__(self, tag=None):
+        if tag is None:
+            return self
+        return next(item for item in self.items if item.tag() == tag)
+
+
+class FakeJavaModel:
+    def __init__(self):
+        self.component = FakeComponentList([FakeComponent()])
+
+
+class FakeModel:
+    def __init__(self):
+        self.java = FakeJavaModel()
+
+
+def registered_tools(monkeypatch):
+    model = FakeModel()
+    monkeypatch.setattr(mesh.session_manager, "get_model", lambda name=None: model)
+    monkeypatch.setattr(geometry.session_manager, "get_model", lambda name=None: model)
+    mcp = FakeMCP()
+    mesh.register_mesh_tools(mcp)
+    geometry.register_geometry_tools(mcp)
+    return model, mcp.tools
+
+
+def test_mesh_create_auto_creates_and_runs_sequence(monkeypatch):
+    model, tools = registered_tools(monkeypatch)
+
+    result = tools["mesh_create"]()
+
+    created = model.java.component("comp1").mesh("mesh1")
+    assert result["success"] is True
+    assert result["auto_created"] is True
+    assert result["meshes"] == ["mesh1"]
+    assert created.geom() == "geom1"
+    assert created.ran is True
+
+
+def test_mesh_list_and_info_use_java_tags(monkeypatch):
+    model, tools = registered_tools(monkeypatch)
+    model.java.component("comp1").mesh().create("mesh_custom", "geom1")
+
+    listed = tools["mesh_list"]()
+    info = tools["mesh_info"](mesh_name="mesh_custom")
+
+    assert listed["meshes"][0]["tag"] == "mesh_custom"
+    assert info["success"] is True
+    assert info["mesh"]["tag"] == "mesh_custom"
+    assert info["mesh"]["geometry"] == "geom1"
+
+
+def test_geometry_create_box_selection(monkeypatch):
+    model, tools = registered_tools(monkeypatch)
+
+    result = tools["geometry_create_box_selection"](
+        selection_name="wave_left",
+        x_min="-1e-9[m]",
+        x_max="1e-9[m]",
+        y_min="0",
+        y_max="1",
+    )
+
+    created = model.java.component("comp1").selection().items["wave_left"]
+    assert result["success"] is True
+    assert result["selection"]["entities"] == [1, 2]
+    assert created.geometry == "geom1"
+    assert created.dimension == 1
+    assert created.properties["condition"] == "intersects"
+
+
+def test_geometry_create_side_selections(monkeypatch):
+    model, tools = registered_tools(monkeypatch)
+
+    result = tools["geometry_create_side_selections"](
+        x_min="0",
+        x_max="2[m]",
+        y_min="0",
+        y_max="1[m]",
+        prefix="wave",
+    )
+
+    selections = model.java.component("comp1").selection().items
+    assert result["success"] is True
+    assert set(selections) == {
+        "wave_left",
+        "wave_right",
+        "wave_bottom",
+        "wave_top",
+    }

--- a/tests/test_physics_acoustic_pde.py
+++ b/tests/test_physics_acoustic_pde.py
@@ -1,0 +1,319 @@
+"""Tests for the specialized Acoustics and PDE physics tools."""
+
+from src.tools import physics
+
+
+class FakeMCP:
+    def __init__(self):
+        self.tools = {}
+
+    def tool(self):
+        def decorator(function):
+            self.tools[function.__name__] = function
+            return function
+
+        return decorator
+
+
+class FakeSelection:
+    def __init__(self):
+        self.values = None
+        self.named_selection = None
+
+    def set(self, values):
+        self.values = values
+
+    def named(self, selection_name):
+        self.named_selection = selection_name
+
+
+class FakeFeature:
+    def __init__(self, tag, feature_type, rejected_properties=None):
+        self._tag = tag
+        self.feature_type = feature_type
+        self._label = feature_type
+        self._selection = FakeSelection()
+        self.properties = {}
+        self.rejected_properties = set(rejected_properties or [])
+
+    def tag(self):
+        return self._tag
+
+    def label(self, value=None):
+        if value is not None:
+            self._label = value
+        return self._label
+
+    def selection(self):
+        return self._selection
+
+    def set(self, name, value):
+        if name in self.rejected_properties:
+            raise ValueError(f"Unsupported property: {name}")
+        self.properties[name] = value
+
+
+class FakePhysics(FakeFeature):
+    def __init__(self, tag, physics_type, dependent_variables=None):
+        super().__init__(tag, physics_type)
+        self.dependent_variables = dependent_variables
+        self.features = {}
+
+    def create(self, tag, feature_type, dimension=None):
+        rejected = ["invalid"] if feature_type == "Impedance" else []
+        feature = FakeFeature(tag, feature_type, rejected)
+        feature.dimension = dimension
+        self.features[tag] = feature
+        return feature
+
+    def feature(self, tag):
+        if tag not in self.features:
+            self.features[tag] = FakeFeature(tag, "Equation")
+        return self.features[tag]
+
+
+class FakePhysicsList:
+    def __init__(self):
+        self.items = []
+
+    def create(self, tag, physics_type, dependent_variables=None):
+        item = FakePhysics(tag, physics_type, dependent_variables)
+        self.items.append(item)
+        return item
+
+    def size(self):
+        return len(self.items)
+
+    def get(self, index):
+        return self.items[index]
+
+    def tags(self):
+        return [item.tag() for item in self.items]
+
+
+class FakeGeometry:
+    def __init__(self, tag="geom1"):
+        self._tag = tag
+
+    def tag(self):
+        return self._tag
+
+    def getSDim(self):
+        return 2
+
+
+class FakeGeometryList:
+    def __init__(self):
+        self.items = [FakeGeometry()]
+
+    def size(self):
+        return len(self.items)
+
+    def get(self, index):
+        return self.items[index]
+
+    def tags(self):
+        return [item.tag() for item in self.items]
+
+
+class FakeComponent:
+    def __init__(self, tag="comp1"):
+        self._tag = tag
+        self._physics = FakePhysicsList()
+        self._geometry = FakeGeometryList()
+
+    def tag(self):
+        return self._tag
+
+    def physics(self, tag=None):
+        if tag is None:
+            return self._physics
+        return next(item for item in self._physics.items if item.tag() == tag)
+
+    def geom(self, tag=None):
+        if tag is None:
+            return self._geometry
+        return next(item for item in self._geometry.items if item.tag() == tag)
+
+
+class FakeComponentList:
+    def __init__(self):
+        self.items = [FakeComponent()]
+
+    def __call__(self, tag=None):
+        if tag is None:
+            return self
+        return next(item for item in self.items if item.tag() == tag)
+
+    def size(self):
+        return len(self.items)
+
+    def get(self, index):
+        return self.items[index]
+
+    def tags(self):
+        return [item.tag() for item in self.items]
+
+
+class FakeJavaModel:
+    def __init__(self):
+        self.component = FakeComponentList()
+
+
+class FakeModel:
+    def __init__(self):
+        self.java = FakeJavaModel()
+
+
+def registered_tools(monkeypatch):
+    model = FakeModel()
+    monkeypatch.setattr(physics.session_manager, "get_model", lambda name=None: model)
+    mcp = FakeMCP()
+    physics.register_physics_tools(mcp)
+    return model, mcp.tools
+
+
+def test_available_interfaces_include_pde(monkeypatch):
+    _, tools = registered_tools(monkeypatch)
+
+    result = tools["physics_get_available"]()
+
+    assert result["success"] is True
+    assert "Mathematics" in result["interfaces"]
+    assert "coefficient_form_pde" in result["interfaces"]["Mathematics"]
+
+
+def test_add_pressure_acoustics(monkeypatch):
+    model, tools = registered_tools(monkeypatch)
+
+    result = tools["physics_add_pressure_acoustics"](
+        domain_selection=[1, 3],
+        component_name="comp1",
+    )
+
+    created = model.java.component("comp1").physics().items[0]
+    assert result["success"] is True
+    assert result["physics"]["type"] == "PressureAcoustics"
+    assert result["physics"]["geometry"] == "geom1"
+    assert created.tag() == "acpr"
+    assert created.selection().values == [1, 3]
+
+
+def test_add_generic_acoustic_interface(monkeypatch):
+    model, tools = registered_tools(monkeypatch)
+
+    result = tools["physics_add_acoustics"](
+        physics_type="ThermoacousticsSinglePhysics",
+        physics_tag="ta",
+        component_name="comp1",
+    )
+
+    created = model.java.component("comp1").physics().items[0]
+    assert result["success"] is True
+    assert result["physics"]["type"] == "ThermoacousticsSinglePhysics"
+    assert result["physics"]["geometry"] == "geom1"
+    assert created.tag() == "ta"
+
+
+def test_add_coefficient_form_pde_with_equation_properties(monkeypatch):
+    model, tools = registered_tools(monkeypatch)
+
+    result = tools["physics_add_coefficient_form_pde"](
+        dependent_variables=["u", "v"],
+        equation_properties={"c": "1", "a": "0", "f": "source"},
+    )
+
+    created = model.java.component("comp1").physics().items[0]
+    assert result["success"] is True
+    assert created.feature("cfeq1").properties == {
+        "c": "1",
+        "a": "0",
+        "f": "source",
+    }
+    assert created.dependent_variables == ["u", "v"]
+
+
+def test_acoustic_boundary_property_failure_is_reported(monkeypatch):
+    model, tools = registered_tools(monkeypatch)
+    acoustic = model.java.component("comp1").physics().create(
+        "acpr",
+        "PressureAcoustics",
+    )
+    acoustic.label("Pressure Acoustics")
+
+    result = tools["physics_configure_acoustic_boundary"](
+        physics_name="Pressure Acoustics",
+        boundary_condition="Impedance",
+        boundary_selection=[2],
+        properties={"Zn": "rho0*c0", "invalid": "value"},
+    )
+
+    assert result["success"] is False
+    assert result["configured_count"] == 0
+    assert result["failed_count"] == 1
+    assert result["failed_boundaries"][0]["dimension"] == 1
+    assert "invalid" in result["failed_boundaries"][0]["property_errors"]
+
+
+def test_pde_boundary_batch_accepts_custom_feature_types(monkeypatch):
+    model, tools = registered_tools(monkeypatch)
+    pde = model.java.component("comp1").physics().create(
+        "c",
+        "CoefficientFormPDE",
+        ["u"],
+    )
+    pde.label("Coefficient Form PDE")
+
+    result = tools["physics_setup_pde_boundaries"](
+        physics_name="Coefficient Form PDE",
+        boundary_conditions=[
+            {
+                "type": "DirichletBoundary",
+                "boundaries": [1],
+                "properties": {"r": "1"},
+            },
+            {
+                "type": "VersionSpecificBoundary",
+                "boundaries": [2],
+                "properties": {"value": "2"},
+            },
+        ],
+    )
+
+    assert result["success"] is True
+    assert result["configured_count"] == 2
+    assert all(item["dimension"] == 1 for item in result["configured_boundaries"])
+    assert result["custom_condition_types"] == ["VersionSpecificBoundary"]
+
+
+def test_pde_boundary_supports_named_selection_and_alias(monkeypatch):
+    model, tools = registered_tools(monkeypatch)
+    pde = model.java.component("comp1").physics().create(
+        "c",
+        "CoefficientFormPDE",
+        ["eta"],
+    )
+    pde.label("Coefficient Form PDE")
+
+    result = tools["physics_configure_pde_boundary"](
+        physics_name="Coefficient Form PDE",
+        boundary_condition="zero_flux",
+        selection_name="wave_top",
+    )
+
+    created = next(iter(pde.features.values()))
+    assert result["success"] is True
+    assert result["configured_boundaries"][0]["type"] == "ZeroFluxBoundary"
+    assert result["configured_boundaries"][0]["selection_name"] == "wave_top"
+    assert created.selection().named_selection == "wave_top"
+
+
+def test_pde_boundary_reference_matches_comsol_63(monkeypatch):
+    _, tools = registered_tools(monkeypatch)
+
+    result = tools["physics_get_pde_boundary_conditions"]()
+
+    conditions = result["boundary_conditions"]
+    assert "ZeroFluxBoundary" in conditions
+    assert "WeakContribution" in conditions
+    assert "GeneralFluxBoundary" not in conditions


### PR DESCRIPTION
## Summary

Extends the COMSOL MCP server with dedicated Acoustics and PDE support, position-based boundary selections, and reliable mesh sequence creation.

### Acoustics and PDE physics

- Added `physics_add_acoustics` for geometry-based acoustic interfaces.
- Added `physics_add_pressure_acoustics`.
- Added dedicated tools for:
  - `CoefficientFormPDE`
  - `GeneralFormPDE`
  - `WeakFormPDE`
- Added equation-property and dependent-variable configuration during PDE creation.
- Added single and batch boundary configuration tools for Acoustics and PDE interfaces.

### Boundary conditions and selections

- Added `geometry_create_box_selection` for selecting geometry entities by position.
- Added `geometry_create_side_selections` for generating named left, right, top, and bottom selections.
- Added `selection_name` support to Acoustics and PDE boundary tools while preserving numeric `boundary_selection` compatibility.
- Added PDE boundary aliases such as:
  - `dirichlet` → `DirichletBoundary`
  - `flux` / `neumann` → `FluxBoundary`
  - `zero_flux` / `no_flux` / `wall` → `ZeroFluxBoundary`
  - `weak` → `WeakContribution`
  - `periodic` → `PeriodicCondition`
- Corrected the COMSOL 6.3 PDE boundary registry by removing unsupported `GeneralFluxBoundary`.
- Boundary property-setting failures are now returned through `property_errors` instead of being silently ignored.

### Mesh sequence support

- Added `mesh_create_sequence`.
- Updated `mesh_create` to automatically create and run `mesh1` when no mesh sequence exists.
- Reworked `mesh_list` and `mesh_info` to use stable COMSOL Java tags instead of MPh labels.
- Converted returned Java strings to Python strings for reliable MCP JSON serialization.

### Documentation and tests

- Updated the English and Chinese READMEs with the new tools.
- Extended the existing boundary-condition property tables with Acoustics and PDE feature/property names.
- Added regression tests for:
  - Acoustic and PDE physics creation
  - PDE equation properties
  - Boundary aliases and named selections
  - COMSOL 6.3 boundary-type mappings
  - Mesh sequence creation and automatic meshing
  - Java-tag-based mesh listing and inspection
  - Box and side selections

## Why

The existing MCP tools could not reliably support acoustic or PDE workflows that require:

- Configuring PDE-dependent variables and equation coefficients
- Applying inlet, radiation, wall, zero-flux, weak, or periodic boundary conditions
- Selecting boundaries by geometric position instead of unstable entity numbers
- Creating a mesh sequence when a model does not already contain one

These changes provide the minimum reusable workflow needed for pressure-acoustics and water-wave PDE models.

## Example

```python
geometry_create_side_selections(
    x_min="0",
    x_max="2[m]",
    y_min="0",
    y_max="1[m]",
    prefix="wave",
)

physics_add_coefficient_form_pde(
    dependent_variables=["eta"],
    equation_properties={
        "c": "h",
        "a": "omega^2/g_const",
        "f": "0",
        "da": "0",
        "ea": "0",
    },
)

physics_configure_pde_boundary(
    physics_name="c",
    boundary_condition="dirichlet",
    selection_name="wave_left",
    properties={"r": "eta0"},
)

physics_configure_pde_boundary(
    physics_name="c",
    boundary_condition="zero_flux",
    selection_name="wave_top",
)

mesh_create(auto_create=True)
```

## Validation

- 12 new regression tests passed.
- MCP stdio initialization and tool discovery passed.
- Confirmed registration of 93 MCP tools.
- `git diff --check` passed.
- Validated with a local COMSOL 6.3 model:
  - Position-based side selections returned boundary entities.
  - `ZeroFluxBoundary` successfully referenced a named selection.
  - `mesh1` was automatically created and executed.
  - `mesh_list` and `mesh_info` resolved the mesh through its Java tag.
  - MCP results were JSON serializable.

## Compatibility

- Existing numeric boundary-selection calls remain supported.
- Custom COMSOL boundary feature types and properties can still be passed through.
- Boundary feature and property names are case-sensitive.
- The Acoustics and PDE mappings in this PR were validated with COMSOL 6.3; availability may vary between COMSOL versions and licensed modules.
- No `.mph`, `.mph.lock`, temporary validation files, or `__pycache__` files are included in this PR.

🤖 Generated with [Codex](https://chatgpt.com/codex/)