### PR TITLE
Pin MCP SDK below version 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "MCP Server for COMSOL Multiphysics simulation automation"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "mcp>=1.0.0",
+    "mcp>=1.0.0,<2.0.0",
     "mph>=1.3.0",
     "pydantic>=2.0.0",
     "pymupdf>=1.24.0",


### PR DESCRIPTION
## Summary

  - Constrain the MCP dependency to `mcp>=1.0.0,<2.0.0`.
  - Preserve compatibility with the existing `mcp.server.fastmcp.FastMCP` integration.

  ## Problem

  The previous dependency specification had no upper bound, so a clean installation could resolve MCP SDK 2.x. The current server still uses the MCP 1.x FastMCP API, causing startup to fail before any tools
  are registered.

  ## Validation

  - Built the project wheel successfully.
  - Verified the wheel metadata contains:

    `Requires-Dist: mcp<2.0.0,>=1.0.0`

  Fixes #10.