### PR TITLE
docs: add paper citation and citation guidance

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,30 @@
+cff-version: 1.2.0
+message: "If you use COMSOL-MCP in your research, please cite both the associated paper and this software."
+title: "COMSOL Multiphysics MCP"
+type: software
+authors:
+  - family-names: "Zhang"
+    given-names: "Naiyin"
+    orcid: "https://orcid.org/0000-0002-4005-1852"
+  - family-names: "Wang"
+    given-names: "Junchao"
+    orcid: "https://orcid.org/0000-0002-6749-1858"
+repository-code: "https://github.com/wjc9011/COMSOL_Multiphysics_MCP"
+url: "https://github.com/wjc9011/COMSOL_Multiphysics_MCP"
+license: MIT
+preferred-citation:
+  type: article
+  authors:
+    - family-names: "Zhang"
+      given-names: "Naiyin"
+      orcid: "https://orcid.org/0000-0002-4005-1852"
+    - family-names: "Wang"
+      given-names: "Junchao"
+      orcid: "https://orcid.org/0000-0002-6749-1858"
+  title: "COMSOL-MCP: An open-source model context protocol interface for AI-assisted multiphysics simulation"
+  journal: "Neurocomputing"
+  volume: 703
+  issue: 134481
+  year: 2026
+  doi: "10.1016/j.neucom.2026.134481"
+  url: "https://doi.org/10.1016/j.neucom.2026.134481"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -24,7 +24,7 @@ preferred-citation:
   title: "COMSOL-MCP: An open-source model context protocol interface for AI-assisted multiphysics simulation"
   journal: "Neurocomputing"
   volume: 703
-  issue: 134481
+  start: 134481
   year: 2026
   doi: "10.1016/j.neucom.2026.134481"
   url: "https://doi.org/10.1016/j.neucom.2026.134481"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,35 @@ English | [中文](README_CN.md)
 
 [![Star History Chart](https://starchart.cc/wjc9011/COMSOL_Multiphysics_MCP.svg)](https://starchart.cc/wjc9011/COMSOL_Multiphysics_MCP)
 
+## Publication and Citation
+
+The research paper describing COMSOL-MCP is available in *Neurocomputing*:
+
+> Naiyin Zhang and Junchao Wang, “[COMSOL-MCP: An open-source model context protocol interface for AI-assisted multiphysics simulation](https://doi.org/10.1016/j.neucom.2026.134481),” *Neurocomputing*, vol. 703, article 134481, 2026.
+
+Publisher page: [ScienceDirect](https://linkinghub.elsevier.com/retrieve/pii/S0925231226018795)
+
+If COMSOL-MCP contributes to your research, please cite the paper:
+
+```bibtex
+@article{Zhang2026COMSOLMCP,
+  title   = {COMSOL-MCP: An Open-Source Model Context Protocol Interface for AI-Assisted Multiphysics Simulation},
+  author  = {Zhang, Naiyin and Wang, Junchao},
+  journal = {Neurocomputing},
+  volume  = {703},
+  pages   = {134481},
+  year    = {2026},
+  doi     = {10.1016/j.neucom.2026.134481},
+  url     = {https://doi.org/10.1016/j.neucom.2026.134481}
+}
+```
+
+### Citation guidance
+
+- Cite the paper when referring to the COMSOL-MCP method, architecture, capabilities, or evaluation.
+- If you use or modify the software, cite both the paper and the repository. Use GitHub’s **Cite this repository** menu, which is backed by [`CITATION.cff`](CITATION.cff).
+- For reproducibility, identify the exact release tag or commit used and include the repository URL and access date in your data/code availability statement.
+
 ## Project Goal
 
 Build a complete COMSOL MCP Server enabling AI agents (like Claude, opencode) to perform multiphysics simulations through the MCP protocol:

--- a/README_CN.md
+++ b/README_CN.md
@@ -10,6 +10,35 @@
 
 [![Star History Chart](https://starchart.cc/wjc9011/COMSOL_Multiphysics_MCP.svg)](https://starchart.cc/wjc9011/COMSOL_Multiphysics_MCP)
 
+## 📄 相关论文与引用
+
+介绍 COMSOL-MCP 的研究论文已发表于 *Neurocomputing*：
+
+> Naiyin Zhang and Junchao Wang, “[COMSOL-MCP: An open-source model context protocol interface for AI-assisted multiphysics simulation](https://doi.org/10.1016/j.neucom.2026.134481),” *Neurocomputing*, vol. 703, article 134481, 2026.
+
+出版商页面：[ScienceDirect](https://linkinghub.elsevier.com/retrieve/pii/S0925231226018795)
+
+如果 COMSOL-MCP 对您的研究有帮助，请引用该论文：
+
+```bibtex
+@article{Zhang2026COMSOLMCP,
+  title   = {COMSOL-MCP: An Open-Source Model Context Protocol Interface for AI-Assisted Multiphysics Simulation},
+  author  = {Zhang, Naiyin and Wang, Junchao},
+  journal = {Neurocomputing},
+  volume  = {703},
+  pages   = {134481},
+  year    = {2026},
+  doi     = {10.1016/j.neucom.2026.134481},
+  url     = {https://doi.org/10.1016/j.neucom.2026.134481}
+}
+```
+
+### 引用指引
+
+- 介绍 COMSOL-MCP 的方法、架构、功能或评估结果时，请引用上述论文。
+- 使用或修改本软件时，建议同时引用论文和代码仓库。可使用 GitHub 的 **Cite this repository**（引用此仓库）菜单；引用信息由 [`CITATION.cff`](CITATION.cff) 提供。
+- 为确保研究可复现，请注明所使用的具体发布版本或 commit，并在数据/代码可用性声明中附上仓库链接和访问日期。
+
 ## 🎯 项目目标
 
 构建完整的 COMSOL MCP Server，使 AI 代理能够通过 MCP 协议执行多物理场仿真：


### PR DESCRIPTION
## What changed

- add the published COMSOL-MCP paper, DOI, and ScienceDirect link to the English README
- add the same publication and citation guidance to the Chinese README
- include a ready-to-copy BibTeX entry
- add `CITATION.cff` so GitHub can expose the **Cite this repository** menu

## Why

The repository now has an associated peer-reviewed publication in *Neurocomputing*. These updates make the paper discoverable from the project page and tell researchers how to cite both the method and the software version they used.

## Validation

- confirmed bibliographic metadata against the Elsevier landing page and Crossref
- confirmed DOI `10.1016/j.neucom.2026.134481` and PII `S0925231226018795` links resolve successfully
- parsed `CITATION.cff` as YAML and verified the preferred citation DOI
- reviewed the branch diff: only `README.md`, `README_CN.md`, and `CITATION.cff` are changed
